### PR TITLE
issue #7

### DIFF
--- a/scrapely/__init__.py
+++ b/scrapely/__init__.py
@@ -32,7 +32,7 @@ class Scraper(object):
         self._templates.append(template)
         self._ex = None
 
-    def train_from_htmlpage(self, htmlpage, data):
+    def train_from_htmlpage(self, htmlpage, data, weights=None, allow_html_dict=None):
         assert data, "Cannot train with empty data"
         tm = TemplateMaker(htmlpage)
         for field, values in data.items():
@@ -41,12 +41,14 @@ class Scraper(object):
                 values = [values]
             for value in values:
                 value = str_to_unicode(value, htmlpage.encoding)
-                tm.annotate(field, best_match(value))
+                weight = weights[field] if weights else 1.0
+                allow_html = allow_html_dict[field] if allow_html_dict else True
+                tm.annotate(field, best_match(value), weight=weight, allow_html=allow_html)
         self.add_template(tm.get_template())
 
-    def train(self, url, data, encoding=None):
+    def train(self, url, data, encoding=None, weights=None, allow_html_dict=None):
         page = url_to_page(url, encoding)
-        self.train_from_htmlpage(page, data)
+        self.train_from_htmlpage(page, data, weights, allow_html_dict)
 
     def scrape(self, url, encoding=None):
         page = url_to_page(url, encoding)

--- a/scrapely/extraction/__init__.py
+++ b/scrapely/extraction/__init__.py
@@ -17,6 +17,7 @@ Main departures from the original algorithm:
       suffix.
 """
 from operator import itemgetter
+from scrapely.extractors import _is_contain_html
 from .pageparsing import parse_template, parse_extraction_page
 from .pageobjects import TokenDict
 from .regionextract import (BasicTypeExtractor, TraceExtractor, RepeatedDataExtractor,
@@ -135,7 +136,7 @@ class InstanceBasedLearningExtractor(object):
             # Sum the weights of extracted values.
             for field, value in correctly_extracted[0].items():
                 allow_html = annotations_allow_html.get(field, True)
-                if not (self._is_contain_html(value[0]) and not allow_html):
+                if not (_is_contain_html(value[0]) and not allow_html):
                     weight += annotations_weights.get(field, 1.0)
 
             if weight > max_weight:
@@ -152,17 +153,6 @@ class InstanceBasedLearningExtractor(object):
     @staticmethod
     def _filter_not_none(items):
         return [d for d in items if d is not None]
-
-    @staticmethod
-    def _is_contain_html(value):
-        """
-        Check if text contain html
-        :param text: string -- text
-        :return: boolean
-        """
-        from bs4 import BeautifulSoup
-        result = bool(BeautifulSoup(value, "html.parser").find())
-        return result
 
 def _annotation_count(template):
     return len(template.annotations)

--- a/scrapely/extraction/__init__.py
+++ b/scrapely/extraction/__init__.py
@@ -17,7 +17,7 @@ Main departures from the original algorithm:
       suffix.
 """
 from operator import itemgetter
-from scrapely.extractors import _is_contain_html
+from scrapely.extractors import is_contain_html
 from .pageparsing import parse_template, parse_extraction_page
 from .pageobjects import TokenDict
 from .regionextract import (BasicTypeExtractor, TraceExtractor, RepeatedDataExtractor,
@@ -136,7 +136,7 @@ class InstanceBasedLearningExtractor(object):
             # Sum the weights of extracted values.
             for field, value in correctly_extracted[0].items():
                 allow_html = annotations_allow_html.get(field, True)
-                if not (_is_contain_html(value[0]) and not allow_html):
+                if not (is_contain_html(value[0]) and not allow_html):
                     weight += annotations_weights.get(field, 1.0)
 
             if weight > max_weight:

--- a/scrapely/extractors.py
+++ b/scrapely/extractors.py
@@ -54,6 +54,17 @@ _TAGS_TO_REPLACE = {
 _TAGS_TO_PURGE = ('script', 'img', 'input')
 
 
+def _is_contain_html(value):
+    """
+    Check if text contain html
+    :param text: string -- text
+    :return: boolean
+    """
+    from bs4 import BeautifulSoup
+    result = bool(BeautifulSoup(value, "html.parser").find())
+    return result
+
+
 def htmlregion(text):
     """convenience function to make an html region from text.
     This is useful for testing

--- a/scrapely/extractors.py
+++ b/scrapely/extractors.py
@@ -54,7 +54,7 @@ _TAGS_TO_REPLACE = {
 _TAGS_TO_PURGE = ('script', 'img', 'input')
 
 
-def _is_contain_html(value):
+def is_contain_html(value):
     """
     Check if text contain html
     :param text: string -- text

--- a/scrapely/template.py
+++ b/scrapely/template.py
@@ -21,7 +21,7 @@ class TemplateMaker(object):
     def __init__(self, htmlpage):
         self.htmlpage = copy.copy(htmlpage)
 
-    def annotate(self, field, score_func, best_match=True):
+    def annotate(self, field, score_func, best_match=True, weight=1, allow_html=True):
         """Annotate a field.
 
         ``score_func`` is a callable that receives two arguments: (fragment,
@@ -41,7 +41,7 @@ class TemplateMaker(object):
         if best_match:
             del indexes[1:]
         for i in indexes:
-            self.annotate_fragment(i, field)
+            self.annotate_fragment(i, field, weight, allow_html)
 
     def select(self, score_func):
         """Return the indexes of fragment where score_func returns a positive
@@ -75,13 +75,13 @@ class TemplateMaker(object):
                     anlist.append((an, i))
         return anlist
 
-    def annotate_fragment(self, index, field, weight=1):
+    def annotate_fragment(self, index, field, weight=1, allow_html=True):
         for f in self.htmlpage.parsed_body[index::-1]:
             if isinstance(f, HtmlTag) and f.tag_type == HtmlTagType.OPEN_TAG:
                 if 'data-scrapy-annotate' in f.attributes:
                     fstr = self.htmlpage.fragment_data(f)
                     raise FragmentAlreadyAnnotated("Fragment already annotated: %s" % fstr)
-                d = {'annotations': {'content': field, 'weight': weight}}
+                d = {'annotations': {'content': field, 'weight': weight, 'allow_html': allow_html}}
                 a = ' data-scrapy-annotate="%s"' % json.dumps(d).replace('"', '&quot;')
                 p = self.htmlpage
                 p.body = p.body[:f.end-1] + a + p.body[f.end-1:]


### PR DESCRIPTION
Adding weight to each annotation (field) to get the data from the template which have max weight, also adding option which constrain if the result of the annotation can have HTML tags or not.

**The adding weighs options:**
result_contains_html, is_allow_html, adding_weights
False,                         False,              True.
False,                         True ,               True.
True ,                          False,              False.
True ,                          True ,              True.

**Description of the table:**
- if the result doesn't contain HTML and HTML is not allowed -> weight of the annotation will be added.
- if the result doesn't contain HTML and HTML is allowed -> weight of the annotation will be added.
- if the result contains HTML and HTML is not allowed -> weight of the annotation will NOT be added.
- if the result contains HTML and HTML is allowed -> weight of the annotation will be added.

**Training set should be something like that:**
{'url': 'https://www.yashry.com/product/6799326/Xls-Medical-Max-Strength-Diet-Pills-For-Weight-Loss-Pack-Of-120',
                 'data': {'price': '735 EGP', 'stock_status': 'Qty:'},
                 'weights': {'price': 45, 'stock_status': 50},
                 'allow_html': {'price': True, 'stock_status': True}
                 }
